### PR TITLE
Update block-list.txt

### DIFF
--- a/block-list.txt
+++ b/block-list.txt
@@ -177,3 +177,4 @@ nterra2.at
 theconnectweb.xyz
 meta-merging.com
 thevmos.org
+keplr-wallet.at


### PR DESCRIPTION
Domain currently used in scam proposal wave on Juno mainnet.

