### PR TITLE
Update block-list.txt

### DIFF
--- a/block-list.txt
+++ b/block-list.txt
@@ -1,3 +1,5 @@
+boomchange.com
+boomchange.io
 keplr-vvallet-app.online
 xn--kplr-vva.com
 keplr-vvallet.tech


### PR DESCRIPTION
**Details:**
"Boomchange.com" & "Boomchange.io" are fake cryptocurrency exchange websites that are designed to scam users. These websites pretend to be legitimate exchange platforms but are actually fraudulent in nature. Their representatives lure people to invest in their platform by offering attractive returns, but once people make investments, the company disappears with their funds. 

Many users have reported falling victim to this scam, losing large sums of money in the process. The fraudulent activities of Boomchange.com and Boomchange.io have been reported in detail on the Bitcoin Talk forum, which can be found at https://bitcointalk.org/index.php?topic=5454622.0

**Changes:**
Added to phishing-block-list:
boomchange.com
boomchange.io